### PR TITLE
added encode/decode message using higher-kinded-type workaround

### DIFF
--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -1,5 +1,5 @@
 use std::borrow::Borrow;
-use std::option::{Option};
+use std::result::{Result};
 
 pub trait Axolotl {
     type PrivateKey : Clone;
@@ -47,7 +47,7 @@ pub trait Axolotl {
         &self,
         message_key : &Self::MessageKey,
         cyphertext : &Self::CipherText) 
-    -> Option<Self::PlainText>;
+    -> Result<Self::PlainText,()>;
 
     fn authenticate_message(
         &self,
@@ -65,10 +65,10 @@ pub trait Axolotl {
     ) -> Self::Message;
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> (usize, <&'a Self::Message as AxolotlMessageRef<Self>>::RatchetKey);
+    ) -> Result<(usize, <&'a Self::Message as AxolotlMessageRef<Self>>::RatchetKey),()>;
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message
-    ) -> <&'a Self::Message as AxolotlMessageRef<Self>>::CipherText;
+    ) -> Result<<&'a Self::Message as AxolotlMessageRef<Self>>::CipherText,()>;
 
     fn ratchet_keys_are_equal(
         &self,

--- a/src/axolotl/message.rs
+++ b/src/axolotl/message.rs
@@ -1,7 +1,0 @@
-use super::axolotl::{Axolotl};
-
-pub struct AxolotlMessage<T> where T:Axolotl {
-    pub message_number : usize,
-    pub ratchet_key : T::PublicKey,
-    pub ciphertext : T::CipherText,
-}

--- a/src/axolotl/mod.rs
+++ b/src/axolotl/mod.rs
@@ -1,7 +1,5 @@
 mod axolotl;
-mod message;
 mod state;
 
-pub use self::axolotl::{Axolotl, KeyPair};
-pub use self::message::{AxolotlMessage};
+pub use self::axolotl::{Axolotl, AxolotlMessageRef, KeyPair};
 pub use self::state::{AxolotlState,init_as_alice,init_as_alice_with_explicit_ratchet_keypair,init_as_bob};

--- a/src/axolotl/state.rs
+++ b/src/axolotl/state.rs
@@ -1,5 +1,5 @@
-use super::axolotl::{Axolotl, KeyPair};
-use super::message::{AxolotlMessage};
+use std::borrow::Borrow;
+use super::axolotl::{Axolotl, AxolotlMessageRef, KeyPair};
 
 pub struct AxolotlState<T> where T:Axolotl {
     root_key : T::RootKey,
@@ -132,34 +132,36 @@ impl <T:Axolotl> ReceiveChain<T> {
         return Some(self.message_keys.len()-1);
     }
 
-    fn try_decrypt_with_message_key_index(
+    fn try_decrypt_with_message_key_index<'a> (
         &self,
         axolotl_impl : &T,
-        message : &AxolotlMessage<T>, 
+        message : &'a T::Message, 
         mac : T::Mac,
         sender_identity : &T::PublicKey, 
         receiver_identity : &T::PublicKey,
         message_key_index : usize,
-    ) -> Option<T::PlainText> {
+    ) -> Option<T::PlainText> where &'a T::Message : AxolotlMessageRef<T> {
         let (_,ref message_key) = self.message_keys[message_key_index];
         let expected_mac = axolotl_impl.authenticate_message(message, message_key, sender_identity, receiver_identity);
         if expected_mac == mac {
-            axolotl_impl.decrypt_message(&message_key, &message.ciphertext)
+            let ciphertext = axolotl_impl.decode_ciphertext(message);
+            axolotl_impl.decrypt_message(&message_key, ciphertext.borrow())
         }
         else {
             None
         }
     }
 
-    fn try_decrypt(
+    fn try_decrypt<'a>(
         &mut self,
         axolotl_impl : &T,
-        message : &AxolotlMessage<T>, 
+        message_number : usize,
+        message : &'a T::Message, 
         mac : T::Mac,
         sender_identity : &T::PublicKey, 
         receiver_identity : &T::PublicKey,
-    ) -> Option<T::PlainText> {
-        self.try_get_message_key_index(axolotl_impl, message.message_number)
+    ) -> Option<T::PlainText> where &'a T::Message : AxolotlMessageRef<T> {
+        self.try_get_message_key_index(axolotl_impl, message_number)
             .and_then(|message_key_index| {
                 let plaintext = self.try_decrypt_with_message_key_index(
                     axolotl_impl,
@@ -178,60 +180,69 @@ impl <T:Axolotl> ReceiveChain<T> {
 }
 impl <T:Axolotl> AxolotlState<T> {
 
-    pub fn encrypt(&mut self, axolotl_impl : &T, plaintext : &T::PlainText) -> (AxolotlMessage<T>, T::Mac) {
+    pub fn encrypt(&mut self, axolotl_impl : &T, plaintext : &T::PlainText) -> (T::Message, T::Mac) {
         let (new_chain_key,result) = self.encrypt_and_get_next_chain_key(axolotl_impl, plaintext);
         self.chain_key_send = new_chain_key;
         self.message_number_send += 1;
         result
     }
 
-    fn encrypt_and_get_next_chain_key(&self, axolotl_impl : &T, plaintext : &T::PlainText) -> (T::ChainKey, (AxolotlMessage<T>, T::Mac)) {
+    fn encrypt_and_get_next_chain_key(&self, axolotl_impl : &T, plaintext : &T::PlainText) -> (T::ChainKey, (T::Message, T::Mac)) {
         let (new_chain_key, message_key) = axolotl_impl.derive_next_chain_and_message_key(&self.chain_key_send);
         let ciphertext = axolotl_impl.encrypt_message(&message_key, plaintext);
 
-        let message = AxolotlMessage {
-            message_number : self.message_number_send,
-            ratchet_key : self.ratchet_key_send.public.clone(),
-            ciphertext : ciphertext
-        };
+        let message = axolotl_impl.encode_header_and_ciphertext(
+            self.message_number_send,
+            self.ratchet_key_send.public.clone(),
+            ciphertext
+        );
         let mac = axolotl_impl.authenticate_message(&message, &message_key, &self.identity_key_remote, &self.identity_key_local);
 
         (new_chain_key,(message,mac))
     }
 
-    pub fn decrypt(&mut self, axolotl_impl : &T, message : &AxolotlMessage<T>, mac : T::Mac) -> Option<T::PlainText> {
+    pub fn decrypt<'a>(&mut self, axolotl_impl : &T, message : &'a T::Message, mac : T::Mac
+    ) -> Option<T::PlainText> where &'a T::Message : AxolotlMessageRef<T> {
+        let (message_number, message_ratchet_key) = axolotl_impl.decode_header(message);
         let receive_chain_position =  self.receive_chains.iter().position(
-            | &ReceiveChain{ref ratchet_key, ..} | axolotl_impl.ratchet_keys_are_equal(ratchet_key, &message.ratchet_key)
+            | &ReceiveChain{ref ratchet_key, ..} | axolotl_impl.ratchet_keys_are_equal(ratchet_key, message_ratchet_key.borrow())
         );
 
         match receive_chain_position {
             Some(pos) => {
                 let receive_chain = &mut self.receive_chains[pos];
-                receive_chain.try_decrypt(axolotl_impl, message, mac, &self.identity_key_local, &self.identity_key_remote)
+                receive_chain.try_decrypt(axolotl_impl, message_number, message, mac, &self.identity_key_local, &self.identity_key_remote)
             }
             None => {
-                self.try_decrypt_with_new_chain(axolotl_impl, message, mac)
+                self.try_decrypt_with_new_chain(axolotl_impl, message_number, message_ratchet_key.borrow(), message, mac)
             }
                 
         }
     }
 
-    fn try_decrypt_with_new_chain(&mut self, axolotl_impl : &T, message : &AxolotlMessage<T>, mac : T::Mac) -> Option<T::PlainText> {
-        let ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&self.ratchet_key_send.key, &message.ratchet_key);
+    fn try_decrypt_with_new_chain<'a>(
+        &mut self, 
+        axolotl_impl : &T, 
+        message_number : usize,
+        message_ratchet_key : &T::PublicKey,
+        message : &'a T::Message, 
+        mac : T::Mac
+    ) -> Option<T::PlainText>  where &'a T::Message : AxolotlMessageRef<T>{
+        let ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&self.ratchet_key_send.key, message_ratchet_key);
         let (receiver_root_key, receiver_chain_key) = axolotl_impl.derive_next_root_key_and_chain_key(self.root_key.clone(), &ratchet_key_derive_shared_secret);
         let new_ratchet_key_send = axolotl_impl.generate_ratchet_key_pair();
-        let new_ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&new_ratchet_key_send.key, &message.ratchet_key);
+        let new_ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&new_ratchet_key_send.key, message_ratchet_key);
         let (root_key, chain_key_send) = axolotl_impl.derive_next_root_key_and_chain_key(receiver_root_key, &new_ratchet_key_derive_shared_secret);
         let truncate_to = axolotl_impl.skipped_chain_limit();
 
         let mut new_receive_chain = ReceiveChain {
             chain_key : receiver_chain_key,
             chain_key_index : 0,
-            ratchet_key : message.ratchet_key.clone(),
+            ratchet_key : message_ratchet_key.clone(),
             message_keys : Vec::new(),
         };
 
-        let plaintext = new_receive_chain.try_decrypt(axolotl_impl, message, mac, &self.identity_key_local, &self.identity_key_remote);
+        let plaintext = new_receive_chain.try_decrypt(axolotl_impl, message_number, message, mac, &self.identity_key_local, &self.identity_key_remote);
         if plaintext.is_some() {
             self.receive_chains.insert(0, new_receive_chain);
             self.receive_chains.truncate(truncate_to);

--- a/tests/toy_stream_cipher/mod.rs
+++ b/tests/toy_stream_cipher/mod.rs
@@ -91,13 +91,13 @@ impl Axolotl for Substitution {
         &self,
         key : &u64,
         ciphertext : &Vec<u8>) 
-    -> Option<Vec<u8>> {
+    -> Result<Vec<u8>,()> {
         let mut rng = get_rng(*key);
         let plaintext = ciphertext
             .iter()
             .map(|b| {rng.gen::<u8>() ^ b})
             .collect();
-        Some(plaintext)
+        Ok(plaintext)
     }
 
     fn encode_header_and_ciphertext(
@@ -114,13 +114,13 @@ impl Axolotl for Substitution {
     }
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> (usize, &'a Self::PublicKey) {
-        (message.message_number, &message.ratchet_key)
+    ) -> Result<(usize, &'a Self::PublicKey),()> {
+        Ok((message.message_number, &message.ratchet_key))
     }
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message
-    ) -> &'a Self::CipherText {
-        &message.ciphertext
+    ) -> Result<&'a Self::CipherText,()> {
+        Ok(&message.ciphertext)
     }
 
     fn authenticate_message(&self, _ : &Self::Message, _ : &u64, _ : &u64, _ : &u64) {

--- a/tests/whisper_protocol/text_secure_v3.rs
+++ b/tests/whisper_protocol/text_secure_v3.rs
@@ -1,5 +1,5 @@
 extern crate raxolotl;
-pub use self::raxolotl::axolotl::{Axolotl,AxolotlMessage,KeyPair};
+pub use self::raxolotl::axolotl::{Axolotl,AxolotlMessageRef,KeyPair};
 
 use whisper_protocol::crypto_wrappers::{aes_cbc,curve25519,hkdf,hmac};
 
@@ -68,6 +68,17 @@ pub struct CipherTextAndVersion{
     version : u8,
 }
 
+pub struct Message {
+    pub message_number : usize,
+    pub ratchet_key : curve25519::PublicKey,
+    pub ciphertext : CipherTextAndVersion,
+}
+
+impl<'a> AxolotlMessageRef<TextSecureV3> for &'a Message {
+    type RatchetKey = &'a curve25519::PublicKey;
+    type CipherText = &'a CipherTextAndVersion;
+}
+
 impl Axolotl for TextSecureV3{
     type PrivateKey = curve25519::PrivateKey;
     type PublicKey  = curve25519::PublicKey;
@@ -79,6 +90,7 @@ impl Axolotl for TextSecureV3{
 
     type PlainText = PlainText;
     type CipherText = CipherTextAndVersion;
+    type Message = Message;
 
     type Mac = hmac::MacResult;
 
@@ -151,7 +163,7 @@ impl Axolotl for TextSecureV3{
 
     fn authenticate_message(
         &self,
-        message : &AxolotlMessage<Self>, 
+        message : &Self::Message, 
         message_key : &Self::MessageKey, 
         sender_identity : &Self::PublicKey, 
         receiver_identity : &Self::PublicKey
@@ -162,6 +174,29 @@ impl Axolotl for TextSecureV3{
         mac_state.input(receiver_identity.to_bytes());
         mac_state.input(&message.ciphertext.cipher_text[..]); //TODO: input the version
         hmac::truncate_mac_result(mac_state.result(), 8)
+    }
+
+    fn encode_header_and_ciphertext(
+        &self, 
+        message_number : usize, 
+        ratchet_key : Self::PublicKey, 
+        ciphertext : Self::CipherText
+    ) -> Self::Message {
+        Message {
+            message_number : message_number,
+            ratchet_key : ratchet_key,
+            ciphertext : ciphertext,
+        }
+    }
+
+    fn decode_header<'a>(&self, message : &'a Self::Message
+    ) -> (usize, &'a Self::PublicKey) {
+        (message.message_number, &message.ratchet_key)
+    }
+
+    fn decode_ciphertext<'a>(&self, message : &'a Self::Message
+    ) -> &'a Self::CipherText {
+        &message.ciphertext
     }
 
     fn ratchet_keys_are_equal(&self, key0 : &Self::PublicKey, key1 : &Self::PublicKey) -> bool{

--- a/tests/whisper_protocol/text_secure_v3.rs
+++ b/tests/whisper_protocol/text_secure_v3.rs
@@ -152,13 +152,13 @@ impl Axolotl for TextSecureV3{
         &self,
         message_key : &Self::MessageKey, 
         ciphertext : &Self::CipherText
-    ) -> Option<Self::PlainText>{
+    ) -> Result<Self::PlainText,()>{
         if ciphertext.version != 3 {
-            return None;
+            return Err(());
         }
 
         let result = aes_cbc::decrypt_aes256_cbc_mode(&ciphertext.cipher_text, message_key.cipher_key, message_key.iv);
-        Some(PlainText(result.into_boxed_slice()))
+        Ok(PlainText(result.into_boxed_slice()))
     }
 
     fn authenticate_message(
@@ -190,13 +190,13 @@ impl Axolotl for TextSecureV3{
     }
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> (usize, &'a Self::PublicKey) {
-        (message.message_number, &message.ratchet_key)
+    ) -> Result<(usize, &'a Self::PublicKey),()> {
+        Ok((message.message_number, &message.ratchet_key))
     }
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message
-    ) -> &'a Self::CipherText {
-        &message.ciphertext
+    ) -> Result<&'a Self::CipherText,()> {
+        Ok(&message.ciphertext)
     }
 
     fn ratchet_keys_are_equal(&self, key0 : &Self::PublicKey, key1 : &Self::PublicKey) -> bool{


### PR DESCRIPTION
this is an alternative implementation to the continuation passing style workaround for encode/decode message. the functions are nicer, but the types are uglier.
