### PR TITLE
use previous message number, and allow in-place encryption, separate 3dh

### DIFF
--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::fmt;
 use std::result::{Result};
 
@@ -61,18 +60,16 @@ pub trait Axolotl {
     -> Self::Mac;
 
     fn encode_header_and_ciphertext(
-        &self, 
-        message_number : usize,
-        message_number_prev : usize,
-        ratchet_key : Self::PublicKey, 
+        &self,
+        header : Header<Self>,
         ciphertext : Self::CipherText
     ) -> Self::Message;
 
-    fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> Result<(usize, usize, <&'a Self::Message as AxolotlMessageRef<Self>>::RatchetKey),Self::DecodeError>;
+    fn decode_header(&self, message : &Self::Message
+    ) -> Result<Header<Self>,Self::DecodeError>;
 
-    fn decode_ciphertext<'a>(&self, message : &'a Self::Message
-    ) -> Result<<&'a Self::Message as AxolotlMessageRef<Self>>::CipherText,Self::DecodeError>;
+    fn decode_ciphertext(&self, message : Self::Message
+    ) -> Result<Self::CipherText,Self::DecodeError>;
 
     fn ratchet_keys_are_equal(
         &self,
@@ -91,11 +88,6 @@ pub trait Axolotl {
     fn chain_message_limit(&self) -> usize;
 
     fn skipped_chain_limit(&self) -> usize;
-}
-
-pub trait AxolotlMessageRef<T> where T:Axolotl {
-    type RatchetKey : Borrow<T::PublicKey>;
-    type CipherText : Borrow<T::CipherText>;
 }
 
 pub enum ReceiveError<T> where T:Axolotl {
@@ -125,6 +117,12 @@ impl<T> fmt::Debug for ReceiveError<T> where T:Axolotl {
 pub struct KeyPair<T> where T:Axolotl {
     pub key : T::PrivateKey,
     pub public : T::PublicKey,
+}
+
+pub struct Header<T> where T:Axolotl {
+    pub message_number : usize,
+    pub message_number_prev : usize,
+    pub ratchet_key : T::PublicKey,
 }
 
 impl <T:Axolotl> Clone for KeyPair<T> {

--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -42,13 +42,13 @@ pub trait Axolotl {
     fn encrypt_message(
         &self,
         message_key : &Self::MessageKey,
-        plaintext : &Self::PlainText) 
+        plaintext : Self::PlainText) 
     -> Self::CipherText;
 
     fn decrypt_message(
         &self,
         message_key : &Self::MessageKey,
-        cyphertext : &Self::CipherText) 
+        cyphertext : Self::CipherText) 
     -> Result<Self::PlainText,Self::DecryptError>;
 
     fn authenticate_message(

--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -79,8 +79,6 @@ pub trait Axolotl {
 
     fn derive_shared_secret(&self, key : &Self::PrivateKey, public : &Self::PublicKey) -> Self::SharedSecret;
 
-    fn derive_public_key(&self, key : &Self::PrivateKey) -> Self::PublicKey;
-
     fn future_message_limit(&self) -> usize;
 
     fn chain_message_limit(&self) -> usize;

--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -62,13 +62,14 @@ pub trait Axolotl {
 
     fn encode_header_and_ciphertext(
         &self, 
-        message_number : usize, 
+        message_number : usize,
+        message_number_prev : usize,
         ratchet_key : Self::PublicKey, 
         ciphertext : Self::CipherText
     ) -> Self::Message;
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> Result<(usize, <&'a Self::Message as AxolotlMessageRef<Self>>::RatchetKey),Self::DecodeError>;
+    ) -> Result<(usize, usize, <&'a Self::Message as AxolotlMessageRef<Self>>::RatchetKey),Self::DecodeError>;
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message
     ) -> Result<<&'a Self::Message as AxolotlMessageRef<Self>>::CipherText,Self::DecodeError>;
@@ -103,6 +104,7 @@ pub enum ReceiveError<T> where T:Axolotl {
     InvalidMac,
     MessageNumberTooFarAhead(usize),
     MessageNumberTooLarge(usize),
+    MessageNumberAheadOfChainLength(usize),
     MessageNumberAlreadyUsed(usize),
 }
 
@@ -114,6 +116,7 @@ impl<T> fmt::Debug for ReceiveError<T> where T:Axolotl {
             &ReceiveError::InvalidMac => write!(f, "InvalidMac"),
             &ReceiveError::MessageNumberTooFarAhead(message_number) => write!(f, "MessageNumberTooFarAhead({:?})", message_number),
             &ReceiveError::MessageNumberTooLarge(message_number) => write!(f, "MessageNumberTooLarge({:?})", message_number),
+            &ReceiveError::MessageNumberAheadOfChainLength(message_number) => write!(f, "MessageNumberAheadOfChainLength({:?})", message_number),
             &ReceiveError::MessageNumberAlreadyUsed(message_number) => write!(f, "MessageNumberAlreadyUsed({:?})", message_number),
         }
     }

--- a/src/axolotl/axolotl.rs
+++ b/src/axolotl/axolotl.rs
@@ -5,6 +5,8 @@ pub trait Axolotl {
     type PrivateKey : Clone;
     type PublicKey : Clone;
     type SharedSecret : Clone;
+    type InitialSharedSecret;
+    type SessionIdentity;
 
     type RootKey : Clone;
     type ChainKey : Clone;
@@ -20,10 +22,7 @@ pub trait Axolotl {
     type DecodeError : fmt::Debug;
 
     fn derive_initial_root_key_and_chain_key(
-        &self,
-        local_identity_remote_handshake_dh_secret : &Self::SharedSecret, 
-        local_handshake_remote_identity_dh_secred : &Self::SharedSecret, 
-        local_handshake_remote_handshake_dh_secret : &Self::SharedSecret) 
+        &self, Self::InitialSharedSecret) 
     -> (Self::RootKey, Self::ChainKey);
 
     // This is the DH future secrecy ratchet/
@@ -54,9 +53,8 @@ pub trait Axolotl {
     fn authenticate_message(
         &self,
         message : &Self::Message, 
-        message_key : &Self::MessageKey, 
-        sender_identity : &Self::PublicKey, 
-        receiver_identity : &Self::PublicKey)
+        message_key : &Self::MessageKey,
+        identity : &Self::SessionIdentity)
     -> Self::Mac;
 
     fn encode_header_and_ciphertext(

--- a/src/axolotl/mod.rs
+++ b/src/axolotl/mod.rs
@@ -1,5 +1,5 @@
 mod axolotl;
 mod state;
 
-pub use self::axolotl::{Axolotl, AxolotlMessageRef, KeyPair, ReceiveError};
+pub use self::axolotl::{Axolotl, Header, KeyPair, ReceiveError};
 pub use self::state::{AxolotlState,init_as_alice,init_as_alice_with_explicit_ratchet_keypair,init_as_bob};

--- a/src/axolotl/state.rs
+++ b/src/axolotl/state.rs
@@ -7,18 +7,28 @@ pub struct AxolotlState<T> where T:Axolotl {
     identity_key_local  : T::PublicKey,
     identity_key_remote : T::PublicKey,
     message_number_send : usize,
+    message_number_prev : usize,
 
     chain_key_send : T::ChainKey,
     ratchet_key_send : KeyPair<T>,
 
-    receive_chains : Vec<ReceiveChain<T>>,
+    skipped_receive_chains : Vec<ReceiveChain<T>>,
+    current_receive_chain : Option<(ReceiveChain<T>, T::ChainKey)>,
 }
 
 struct ReceiveChain<T> where T:Axolotl {
-    chain_key : T::ChainKey,
     chain_key_index : usize,
     ratchet_key : T::PublicKey,
     message_keys : Vec<(usize,T::MessageKey)>,
+}
+impl<T:Axolotl> Clone for ReceiveChain<T> {
+    fn clone(&self) -> Self {
+        ReceiveChain{
+            chain_key_index : self.chain_key_index,
+            ratchet_key : self.ratchet_key.clone(),
+            message_keys : self.message_keys.clone(),
+        }
+    }
 }
 
 
@@ -62,7 +72,6 @@ pub fn init_as_alice_with_explicit_ratchet_keypair<T>(
         let ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&ratchet_key.key, initial_ratchet_key);
         let (root_key,chain_key_send) = axolotl_impl.derive_next_root_key_and_chain_key(pre_root_key, &ratchet_key_derive_shared_secret);
         let initial_receive_chain = ReceiveChain {
-            chain_key : chain_key_recv,
             chain_key_index : 0,
             ratchet_key : initial_ratchet_key.clone(),
             message_keys : Vec::new(),
@@ -72,9 +81,11 @@ pub fn init_as_alice_with_explicit_ratchet_keypair<T>(
             identity_key_local : axolotl_impl.derive_public_key(&identity_key_local),
             identity_key_remote : identity_key_remote.clone(),
             message_number_send : 0,
+            message_number_prev : 0,
             chain_key_send : chain_key_send,
             ratchet_key_send : ratchet_key,
-            receive_chains : vec![initial_receive_chain],
+            skipped_receive_chains : Vec::new(),
+            current_receive_chain : Some((initial_receive_chain, chain_key_recv)),
         }
 }
 
@@ -96,55 +107,63 @@ pub fn init_as_bob<T>(
             identity_key_local : axolotl_impl.derive_public_key(&identity_key_local),
             identity_key_remote : identity_key_remote.clone(),
             message_number_send : 0,
+            message_number_prev : 0,
             chain_key_send : chain_key_send,
             ratchet_key_send : initial_ratchet_key,
-            receive_chains : Vec::new(),
+            skipped_receive_chains : Vec::new(),
+            current_receive_chain : None,
         }
 }
 
 
 
 impl <T:Axolotl> ReceiveChain<T> {
-    fn try_get_message_key_index(&mut self, axolotl_impl : &T, index : usize) -> Result<usize,ReceiveError<T>> {
+    fn find_message_key(&self, axolotl_impl : &T, index : usize) -> Result<usize,ReceiveError<T>> {
+        
+        if index >= self.chain_key_index {
+            return Err(ReceiveError::MessageNumberAheadOfChainLength(index));
+        }
+        
+        for i in 0..self.message_keys.len() {
+            let (chain_index, _) = self.message_keys[i];
+            if chain_index == index {
+                return Ok(i);
+            }
+        }
+        return Err(ReceiveError::MessageNumberAlreadyUsed(index));
+    }
+
+    fn create_message_keys(&mut self, axolotl_impl : &T, chain_key : &mut T::ChainKey, index : usize) -> Result<(), ReceiveError<T>> {
         if index > axolotl_impl.chain_message_limit() {
             return Err(ReceiveError::MessageNumberTooLarge(index));
         }
-        //TODO: make sure this doesn't overflow
+
         if index > self.chain_key_index + axolotl_impl.future_message_limit() {
             return Err(ReceiveError::MessageNumberTooFarAhead(index));
         }
-        if index < self.chain_key_index {
-            for i in 0..self.message_keys.len() {
-                let (chain_index, _) = self.message_keys[i];
-                if chain_index == index {
-                    return Ok(i);
-                }
-            }
-            return Err(ReceiveError::MessageNumberAlreadyUsed(index));
-        }
 
+        
         for i in self.chain_key_index..(index+1) {
-            let (next_chain_key, message_key) = axolotl_impl.derive_next_chain_and_message_key(&self.chain_key);
+            let (next_chain_key, message_key) = axolotl_impl.derive_next_chain_and_message_key(chain_key);
             self.message_keys.push((i,message_key));
-            self.chain_key = next_chain_key;
+            *chain_key = next_chain_key;
             self.chain_key_index += 1;
         }
-
-        return Ok(self.message_keys.len()-1);
+        Ok(())
     }
 
     fn try_decrypt_with_message_key_index<'a> (
         &self,
         axolotl_impl : &T,
         message : &'a T::Message, 
-        mac : T::Mac,
+        mac : &T::Mac,
         sender_identity : &T::PublicKey, 
         receiver_identity : &T::PublicKey,
         message_key_index : usize,
     ) -> Result<T::PlainText,ReceiveError<T>> where &'a T::Message : AxolotlMessageRef<T> {
         let (_,ref message_key) = self.message_keys[message_key_index];
         let expected_mac = axolotl_impl.authenticate_message(message, message_key, sender_identity, receiver_identity);
-        if expected_mac == mac {
+        if &expected_mac == mac {
             let ciphertext = try!(axolotl_impl.decode_ciphertext(message).map_err(|e|{ReceiveError::DecodeError(e)}));
             axolotl_impl.decrypt_message(&message_key, ciphertext.borrow()).map_err(|e|{ReceiveError::DecryptError(e)})
         }
@@ -158,11 +177,11 @@ impl <T:Axolotl> ReceiveChain<T> {
         axolotl_impl : &T,
         message_number : usize,
         message : &'a T::Message, 
-        mac : T::Mac,
+        mac : &T::Mac,
         sender_identity : &T::PublicKey, 
         receiver_identity : &T::PublicKey,
     ) -> Result<T::PlainText,ReceiveError<T>> where &'a T::Message : AxolotlMessageRef<T> {
-        self.try_get_message_key_index(axolotl_impl, message_number)
+        self.find_message_key(axolotl_impl, message_number)
             .and_then(|message_key_index| {
                 let plaintext = self.try_decrypt_with_message_key_index(
                     axolotl_impl,
@@ -194,6 +213,7 @@ impl <T:Axolotl> AxolotlState<T> {
 
         let message = axolotl_impl.encode_header_and_ciphertext(
             self.message_number_send,
+            self.message_number_prev,
             self.ratchet_key_send.public.clone(),
             ciphertext
         );
@@ -202,22 +222,60 @@ impl <T:Axolotl> AxolotlState<T> {
         (new_chain_key,(message,mac))
     }
 
-    pub fn decrypt<'a>(&mut self, axolotl_impl : &T, message : &'a T::Message, mac : T::Mac
+    pub fn decrypt<'a>(&mut self, axolotl_impl : &T, message : &'a T::Message, ref mac : T::Mac
     ) -> Result<T::PlainText,ReceiveError<T>> where &'a T::Message : AxolotlMessageRef<T> {
-        let (message_number, message_ratchet_key) = try!(axolotl_impl.decode_header(message).map_err(|e|{ReceiveError::DecodeError(e)}));
-        let receive_chain_position =  self.receive_chains.iter().position(
-            | &ReceiveChain{ref ratchet_key, ..} | axolotl_impl.ratchet_keys_are_equal(ratchet_key, message_ratchet_key.borrow())
+        let (message_number, message_number_prev, message_ratchet_key_ref) = try!(
+            axolotl_impl
+                .decode_header(message)
+                .map_err(|e|{ReceiveError::DecodeError(e)})
         );
+        let message_ratchet_key = message_ratchet_key_ref.borrow();
 
-        match receive_chain_position {
-            Some(pos) => {
-                let receive_chain = &mut self.receive_chains[pos];
-                receive_chain.try_decrypt(axolotl_impl, message_number, message, mac, &self.identity_key_local, &self.identity_key_remote)
-            }
-            None => {
-                self.try_decrypt_with_new_chain(axolotl_impl, message_number, message_ratchet_key.borrow(), message, mac)
-            }
-                
+        if let Some(plaintext) = self.try_decrypt_with_skipped_chain(axolotl_impl, message, mac, message_number, message_ratchet_key) {
+            return plaintext;
+        }
+        if let Some(plaintext) = self.try_decrypt_with_current_chain(axolotl_impl, message, mac, message_number, message_ratchet_key) {
+            return plaintext;
+        }
+        self.try_decrypt_with_new_chain(axolotl_impl, message_number, message_number_prev, message_ratchet_key, message, mac)
+    }
+
+    fn try_decrypt_with_skipped_chain<'a>(
+        &mut self, 
+        axolotl_impl : &T, 
+        message : &'a T::Message, 
+        mac : &T::Mac, 
+        message_number : usize, 
+        message_ratchet_key : &T::PublicKey
+    ) ->  Option<Result<T::PlainText,ReceiveError<T>>> where &'a T::Message : AxolotlMessageRef<T>{
+        self.skipped_receive_chains.iter().position(
+            | &ReceiveChain{ref ratchet_key, ..} | axolotl_impl.ratchet_keys_are_equal(ratchet_key, message_ratchet_key)
+        ).map(|pos| {
+            let receive_chain = &mut self.skipped_receive_chains[pos];
+            receive_chain.try_decrypt(axolotl_impl, message_number, message, mac, &self.identity_key_local, &self.identity_key_remote)
+        })
+    }
+
+    fn try_decrypt_with_current_chain<'a>(
+        &mut self, 
+        axolotl_impl : &T, 
+        message : &'a T::Message, 
+        mac : &T::Mac, 
+        message_number : usize, 
+        message_ratchet_key : &T::PublicKey
+    ) ->  Option<Result<T::PlainText,ReceiveError<T>>> where &'a T::Message : AxolotlMessageRef<T>{
+        match self.current_receive_chain {
+            Some((ref mut current_chain, ref mut chain_key)) => {
+                if !axolotl_impl.ratchet_keys_are_equal(&current_chain.ratchet_key, message_ratchet_key) {
+                    return None;
+                }
+                let ref identity_key_local = self.identity_key_local;
+                let ref identity_key_remote = self.identity_key_remote;
+                Some(current_chain.create_message_keys(axolotl_impl, chain_key, message_number).and_then(|_| {
+                    current_chain.try_decrypt(axolotl_impl, message_number, message, mac, identity_key_local, identity_key_remote)
+                }))
+            },
+            None => None,
         }
     }
 
@@ -225,28 +283,33 @@ impl <T:Axolotl> AxolotlState<T> {
         &mut self, 
         axolotl_impl : &T, 
         message_number : usize,
+        message_number_prev : usize,
         message_ratchet_key : &T::PublicKey,
         message : &'a T::Message, 
-        mac : T::Mac
+        mac : &T::Mac
     ) -> Result<T::PlainText,ReceiveError<T>>  where &'a T::Message : AxolotlMessageRef<T>{
         let ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&self.ratchet_key_send.key, message_ratchet_key);
-        let (receiver_root_key, receiver_chain_key) = axolotl_impl.derive_next_root_key_and_chain_key(self.root_key.clone(), &ratchet_key_derive_shared_secret);
-        let new_ratchet_key_send = axolotl_impl.generate_ratchet_key_pair();
-        let new_ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&new_ratchet_key_send.key, message_ratchet_key);
-        let (root_key, chain_key_send) = axolotl_impl.derive_next_root_key_and_chain_key(receiver_root_key, &new_ratchet_key_derive_shared_secret);
-        let truncate_to = axolotl_impl.skipped_chain_limit();
+        let (receiver_root_key, mut receiver_chain_key) = axolotl_impl.derive_next_root_key_and_chain_key(self.root_key.clone(), &ratchet_key_derive_shared_secret);
 
         let mut new_receive_chain = ReceiveChain {
-            chain_key : receiver_chain_key,
             chain_key_index : 0,
             ratchet_key : message_ratchet_key.clone(),
             message_keys : Vec::new(),
         };
-
+        try!(new_receive_chain.create_message_keys(axolotl_impl, &mut receiver_chain_key, message_number));
         let plaintext = new_receive_chain.try_decrypt(axolotl_impl, message_number, message, mac, &self.identity_key_local, &self.identity_key_remote);
         if plaintext.is_ok() {
-            self.receive_chains.insert(0, new_receive_chain);
-            self.receive_chains.truncate(truncate_to);
+            let new_ratchet_key_send = axolotl_impl.generate_ratchet_key_pair();
+            let new_ratchet_key_derive_shared_secret = axolotl_impl.derive_shared_secret(&new_ratchet_key_send.key, message_ratchet_key);
+            let (root_key, chain_key_send) = axolotl_impl.derive_next_root_key_and_chain_key(receiver_root_key, &new_ratchet_key_derive_shared_secret);
+            let truncate_to = axolotl_impl.skipped_chain_limit();
+            if let Some((ref mut current_chain, ref mut current_chain_key)) = self.current_receive_chain {
+                try!(current_chain.create_message_keys(axolotl_impl, current_chain_key, message_number_prev));
+                self.skipped_receive_chains.insert(0, current_chain.clone());
+                self.skipped_receive_chains.truncate(truncate_to);
+            }
+            self.current_receive_chain = Some((new_receive_chain, receiver_chain_key));
+            self.message_number_prev = self.message_number_send;
             self.message_number_send = 0;
             self.root_key = root_key;
             self.chain_key_send = chain_key_send;

--- a/src/axolotl/state.rs
+++ b/src/axolotl/state.rs
@@ -165,7 +165,7 @@ impl <T:Axolotl> ReceiveChain<T> {
         let expected_mac = axolotl_impl.authenticate_message(&message, message_key, sender_identity, receiver_identity);
         if &expected_mac == mac {
             let ciphertext = try!(axolotl_impl.decode_ciphertext(message).map_err(|e|{ReceiveError::DecodeError(e)}));
-            axolotl_impl.decrypt_message(&message_key, ciphertext.borrow()).map_err(|e|{ReceiveError::DecryptError(e)})
+            axolotl_impl.decrypt_message(&message_key, ciphertext).map_err(|e|{ReceiveError::DecryptError(e)})
         }
         else {
             Err(ReceiveError::InvalidMac)
@@ -200,14 +200,14 @@ impl <T:Axolotl> ReceiveChain<T> {
 }
 impl <T:Axolotl> AxolotlState<T> {
 
-    pub fn encrypt(&mut self, axolotl_impl : &T, plaintext : &T::PlainText) -> (T::Message, T::Mac) {
+    pub fn encrypt(&mut self, axolotl_impl : &T, plaintext : T::PlainText) -> (T::Message, T::Mac) {
         let (new_chain_key,result) = self.encrypt_and_get_next_chain_key(axolotl_impl, plaintext);
         self.chain_key_send = new_chain_key;
         self.message_number_send += 1;
         result
     }
 
-    fn encrypt_and_get_next_chain_key(&self, axolotl_impl : &T, plaintext : &T::PlainText) -> (T::ChainKey, (T::Message, T::Mac)) {
+    fn encrypt_and_get_next_chain_key(&self, axolotl_impl : &T, plaintext : T::PlainText) -> (T::ChainKey, (T::Message, T::Mac)) {
         let (new_chain_key, message_key) = axolotl_impl.derive_next_chain_and_message_key(&self.chain_key_send);
         let ciphertext = axolotl_impl.encrypt_message(&message_key, plaintext);
 

--- a/tests/text_secure_v3_tests.rs
+++ b/tests/text_secure_v3_tests.rs
@@ -13,12 +13,12 @@ fn dynamic_roundtrip_echo(){
 
     for __ in 0..10 {
         let (wm, mac) = alice.encrypt(axolotl_impl, &msg);
-        let plaintext = bob.decrypt(axolotl_impl, &wm,mac).ok().unwrap();
+        let plaintext = bob.decrypt(axolotl_impl, wm,mac).ok().unwrap();
 
         assert_eq!(msg.0 , plaintext.0);
 
         let (wmb, macb) = bob.encrypt(axolotl_impl, &plaintext);
-        let reply = alice.decrypt(axolotl_impl, &wmb,macb).ok().unwrap();
+        let reply = alice.decrypt(axolotl_impl, wmb,macb).ok().unwrap();
 
         assert_eq!(msg.0,reply.0);
     }
@@ -130,21 +130,21 @@ fn android_session_kat () {
     assert_eq!(&alice_cipher_msg.ciphertext.cipher_text[..], &alice_cipher_text[..]);
 
    
-    let bob_plain = bob.decrypt(axolotl_impl, &alice_cipher_msg,ab_mac).ok().unwrap();
+    let bob_plain = bob.decrypt(axolotl_impl, alice_cipher_msg,ab_mac).ok().unwrap();
     assert_eq!(bob_plain.0.to_vec(),&alice_plaintext[..]);
    
     for i in 0 .. 100{
         let message = [i;78];
 
         let (c,m) = alice.encrypt(axolotl_impl, &PlainText::from_vec(message.to_vec()));      
-        assert_eq!(&message[..], &bob.decrypt(axolotl_impl, &c,m).ok().unwrap().0.to_vec()[..] );
+        assert_eq!(&message[..], &bob.decrypt(axolotl_impl, c,m).ok().unwrap().0.to_vec()[..] );
     }
 
     for i in 0 .. 100{
         let message = [i;1802];
 
         let (c,m) = bob.encrypt(axolotl_impl, &PlainText::from_vec(message.to_vec()));
-        assert_eq!(&message[..], &alice.decrypt(axolotl_impl, &c,m).ok().unwrap().0.to_vec()[..] );
+        assert_eq!(&message[..], &alice.decrypt(axolotl_impl, c,m).ok().unwrap().0.to_vec()[..] );
     }
 }
 

--- a/tests/text_secure_v3_tests.rs
+++ b/tests/text_secure_v3_tests.rs
@@ -12,12 +12,12 @@ fn dynamic_roundtrip_echo(){
     let msg = PlainText::from_vec("hello goat!".to_string().into_bytes());
 
     for __ in 0..10 {
-        let (wm, mac) = alice.encrypt(axolotl_impl, &msg);
+        let (wm, mac) = alice.encrypt(axolotl_impl, msg.clone());
         let plaintext = bob.decrypt(axolotl_impl, wm,mac).ok().unwrap();
 
         assert_eq!(msg.0 , plaintext.0);
 
-        let (wmb, macb) = bob.encrypt(axolotl_impl, &plaintext);
+        let (wmb, macb) = bob.encrypt(axolotl_impl, plaintext);
         let reply = alice.decrypt(axolotl_impl, wmb,macb).ok().unwrap();
 
         assert_eq!(msg.0,reply.0);
@@ -126,7 +126,7 @@ fn android_session_kat () {
     let a_plain = PlainText::from_vec(alice_plaintext.to_vec());
 
 
-    let (alice_cipher_msg,ab_mac) = alice.encrypt(axolotl_impl, &a_plain);
+    let (alice_cipher_msg,ab_mac) = alice.encrypt(axolotl_impl, a_plain);
     assert_eq!(&alice_cipher_msg.ciphertext.cipher_text[..], &alice_cipher_text[..]);
 
    
@@ -136,14 +136,14 @@ fn android_session_kat () {
     for i in 0 .. 100{
         let message = [i;78];
 
-        let (c,m) = alice.encrypt(axolotl_impl, &PlainText::from_vec(message.to_vec()));      
+        let (c,m) = alice.encrypt(axolotl_impl, PlainText::from_vec(message.to_vec()));      
         assert_eq!(&message[..], &bob.decrypt(axolotl_impl, c,m).ok().unwrap().0.to_vec()[..] );
     }
 
     for i in 0 .. 100{
         let message = [i;1802];
 
-        let (c,m) = bob.encrypt(axolotl_impl, &PlainText::from_vec(message.to_vec()));
+        let (c,m) = bob.encrypt(axolotl_impl, PlainText::from_vec(message.to_vec()));
         assert_eq!(&message[..], &alice.decrypt(axolotl_impl, c,m).ok().unwrap().0.to_vec()[..] );
     }
 }

--- a/tests/toy_stream_cipher/mod.rs
+++ b/tests/toy_stream_cipher/mod.rs
@@ -138,12 +138,8 @@ impl Axolotl for Substitution {
 
     fn generate_ratchet_key_pair(&self) -> KeyPair<Self> {
         let key = next_rng().next_u64();
-        let public = self.derive_public_key(&key);
+        let public = key.wrapping_mul(31);
         KeyPair{ key : key, public : public }
-    }
-
-    fn derive_public_key(&self,key : &u64) -> u64 {
-        key.wrapping_mul(31)
     }
 
     fn derive_shared_secret(&self,a : &u64, b : &u64) -> u64 {

--- a/tests/toy_stream_cipher/mod.rs
+++ b/tests/toy_stream_cipher/mod.rs
@@ -23,6 +23,7 @@ pub struct Substitution;
 
 pub struct Message {
     pub message_number : usize,
+    pub message_number_prev : usize,
     pub ratchet_key : u64,
     pub ciphertext : Vec<u8>,
 }
@@ -105,20 +106,22 @@ impl Axolotl for Substitution {
 
     fn encode_header_and_ciphertext(
         &self, 
-        message_number : usize, 
+        message_number : usize,
+        message_number_prev : usize,
         ratchet_key : Self::PublicKey, 
         ciphertext : Self::CipherText
     ) -> Self::Message {
         Message {
             message_number : message_number,
+            message_number_prev : message_number_prev,
             ratchet_key : ratchet_key,
             ciphertext : ciphertext,
         }
     }
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> Result<(usize, &'a Self::PublicKey),()> {
-        Ok((message.message_number, &message.ratchet_key))
+    ) -> Result<(usize, usize, &'a Self::PublicKey),()> {
+        Ok((message.message_number, message.message_number_prev, &message.ratchet_key))
     }
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message

--- a/tests/toy_stream_cipher/mod.rs
+++ b/tests/toy_stream_cipher/mod.rs
@@ -77,7 +77,7 @@ impl Axolotl for Substitution {
     fn encrypt_message(
         &self,
         key : &u64,
-        plaintext : &Vec<u8>) 
+        plaintext : Vec<u8>) 
     -> Vec<u8> {
         let mut rng = get_rng(*key);
         plaintext
@@ -90,7 +90,7 @@ impl Axolotl for Substitution {
     fn decrypt_message(
         &self,
         key : &u64,
-        ciphertext : &Vec<u8>) 
+        ciphertext : Vec<u8>) 
     -> Result<Vec<u8>,()> {
         let mut rng = get_rng(*key);
         let plaintext = ciphertext
@@ -192,7 +192,7 @@ pub fn init_alice_and_bob(axolotl_impl : &Substitution) -> (AxolotlState<Substit
 
 pub fn check_send(axolotl_impl : &Substitution, sender : &mut AxolotlState<Substitution>, receiver : &mut AxolotlState<Substitution>, message : String) -> Message {
     let m = message.into_bytes();
-    let encrypted = sender.encrypt(axolotl_impl, &m);
+    let encrypted = sender.encrypt(axolotl_impl, m.clone());
     let decrypted = receiver.decrypt(axolotl_impl, encrypted.0.clone(), encrypted.1).unwrap();
     assert!(m[..] == decrypted[..]);
     assert!(m[..] != encrypted.0.ciphertext[..]);

--- a/tests/whisper_protocol/text_secure_v3.rs
+++ b/tests/whisper_protocol/text_secure_v3.rs
@@ -70,6 +70,7 @@ pub struct CipherTextAndVersion{
 
 pub struct Message {
     pub message_number : usize,
+    pub message_number_prev : usize,
     pub ratchet_key : curve25519::PublicKey,
     pub ciphertext : CipherTextAndVersion,
 }
@@ -182,19 +183,21 @@ impl Axolotl for TextSecureV3{
     fn encode_header_and_ciphertext(
         &self, 
         message_number : usize, 
+        message_number_prev : usize, 
         ratchet_key : Self::PublicKey, 
         ciphertext : Self::CipherText
     ) -> Self::Message {
         Message {
             message_number : message_number,
+            message_number_prev : message_number_prev,
             ratchet_key : ratchet_key,
             ciphertext : ciphertext,
         }
     }
 
     fn decode_header<'a>(&self, message : &'a Self::Message
-    ) -> Result<(usize, &'a Self::PublicKey),()> {
-        Ok((message.message_number, &message.ratchet_key))
+    ) -> Result<(usize, usize, &'a Self::PublicKey),()> {
+        Ok((message.message_number, message.message_number_prev, &message.ratchet_key))
     }
 
     fn decode_ciphertext<'a>(&self, message : &'a Self::Message

--- a/tests/whisper_protocol/text_secure_v3.rs
+++ b/tests/whisper_protocol/text_secure_v3.rs
@@ -206,9 +206,6 @@ impl Axolotl for TextSecureV3{
         KeyPair{ key: priv_key, public : pub_key }
     }
 
-    fn derive_public_key(&self, key : &Self::PrivateKey) -> Self::PublicKey {
-        curve25519::derive_public_key(key)
-    }
     fn derive_shared_secret(&self, mine : &Self::PrivateKey, theirs : &Self::PublicKey) -> Self::SharedSecret {
         curve25519::derive_shared_key( mine,theirs)
     }


### PR DESCRIPTION
previous message number is now used to figure out how many message keys to store for a chain. header related functions use a struct rather than a tuple, since there are now two usize values, and they could use names.

encrypt/decrypt and encode/decode now take parameters by value. this allows an implementor to modify the plaintext in-place and return it as ciphertext, if they wanted to.
