### PR TITLE
Stricter dependency check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 gcc = "0.3"
 
 [dependencies]
-rustc-serialize = "0.3"
+rustc-serialize = "0.3.15"
 rand = "*"
 
 [dev-dependencies]


### PR DESCRIPTION
version 0.3.14 of rustc-serialize causes error when compiling tests.

To avoid the issue of a stale cargo registry causing compilation errors, the required version has been made explicit ( = 0.3.15).
